### PR TITLE
Set the client encoding to utf8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -558,7 +558,7 @@ postgresql_timezone:           UTC
 postgresql_timezone_abbreviations: Default
 
 postgresql_extra_float_digits: 0          # min -15, max 3
-postgresql_client_encoding:    sql_ascii  # 'sql_ascii' actually defaults to database encoding
+postgresql_client_encoding: utf8
 
 # These settings are initialized by initdb, but they can be changed.
 


### PR DESCRIPTION
It was supposed to default to the database encoding but this doesn't
seem to be working.
